### PR TITLE
Rename package name from main to emojiclock

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ package main
 import (
   "fmt"
   "log"
-  . "github.com/ziishaned/emoji-clock"
+  "github.com/ziishaned/emoji-clock"
 )
 
 func main() {
-  emoji, err := TimeToEmoji("2014-03-09T22:47:02.705Z")
+  emoji, err := emojiclock.TimeToEmoji("2014-03-09T22:47:02.705Z")
   if err != nil {
     log.Fatal(err)
   }
   fmt.Println(emoji) // 🕚
   
-  emoji2, err := TimeToEmoji("2018-10-09T21:40:02.705Z")
+  emoji2, err := emojiclock.TimeToEmoji("2018-10-09T21:40:02.705Z")
   if err != nil {
     log.Fatal(err)
   }

--- a/emoji_clock.go
+++ b/emoji_clock.go
@@ -1,4 +1,4 @@
-package main
+package emojiclock
 
 import (
   "time"

--- a/emoji_clock_test.go
+++ b/emoji_clock_test.go
@@ -1,4 +1,4 @@
-package main
+package emojiclock
 
 import (
 	"reflect"


### PR DESCRIPTION
In Go, a package that is not `main` (intended to be run as an executable, not used as a library) should not be named `main`. This PR renames the package to emojiclock and updates documentation as necessary.

https://blog.golang.org/package-names